### PR TITLE
fix: Change TCPServer to ThreadingTCPServer for health check

### DIFF
--- a/health-check/health-check.py
+++ b/health-check/health-check.py
@@ -51,7 +51,7 @@ class HealthCheckHandler(http.server.BaseHTTPRequestHandler):
         pass
 
 if __name__ == "__main__":
-    with socketserver.TCPServer(("", PORT), HealthCheckHandler) as httpd:
+    with socketserver.ThreadingTCPServer(("", PORT), HealthCheckHandler) as httpd:
         print(f"Health check server running on port {PORT}")
         try:
             httpd.serve_forever()


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Replace TCPServer with ThreadingTCPServer for concurrent request handling

- Add missing newline at end of file


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["TCPServer"] -- "replaced with" --> B["ThreadingTCPServer"]
  B --> C["Concurrent Request Handling"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>health-check.py</strong><dd><code>Enable threading for health check server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

health-check/health-check.py

<ul><li>Changed <code>socketserver.TCPServer</code> to <code>socketserver.ThreadingTCPServer</code><br> <li> Added missing newline at end of file</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/aio-harbor-registry-cache/pull/22/files#diff-a9a7e6841dd5feaab4b908162563ddfc30e9afc018e01eda6ec37bd1909009d8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

